### PR TITLE
[fix]: resolve infinite scroll issue on About Page (#18)

### DIFF
--- a/src/components/Components_css/CoreTeam.css
+++ b/src/components/Components_css/CoreTeam.css
@@ -1,3 +1,57 @@
+/* Adjust the container width and padding */
+.core-team {
+  padding: 4rem 2rem; /* Reduced horizontal padding */
+  background: #f9f9f9;
+  text-align: center;
+  overflow: hidden;
+}
+
+/* Modify sliding container for better control */
+.core-team__sliding-container {
+  position: relative;
+  width: 100%;
+  max-width: 1200px; /* Add maximum width */
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+/* Update sliding track animation */
+.core-team__sliding-track {
+  display: flex;
+  gap: 2rem;
+  width: 200%; /* Ensures content is duplicated */
+  animation: slide-horizontal 30s linear infinite; /* Reduced time from 60s to 30s */
+}
+
+/* Adjust card sizing and spacing */
+.core-team__card {
+  flex: 0 0 250px; /* Fixed card width */
+  background: #fff;
+  border-radius: 15px;
+  padding: 1.5rem;
+  box-shadow: 0 6px 20px rgba(56, 125, 255, 0.17);
+  text-align: center;
+  transition: transform 0.3s ease;
+}
+
+/* Update info text visibility */
+.core-team__info p {
+  font-size: 0.9rem;
+  color: #777;
+  margin: 0.2rem 0;
+  opacity: 1; /* Changed from 0 to always visible */
+  transition: opacity 0.3s ease;
+}
+
+/* Remove hover opacity since text is always visible now */
+.core-team__card:hover .core-team__info p {
+  opacity: 1;
+}
+
+/* Optional: Add pause on hover */
+.core-team__sliding-track:hover {
+  animation-play-state: paused;
+}
 .core-team {
   padding: 4rem;
   background: #f9f9f9;

--- a/src/components/CoreTeam.js
+++ b/src/components/CoreTeam.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React,{useEffect} from "react";
 import '../components/Components_css/CoreTeam.css';
 import teamImg1 from '../images/about-img-1.jpg';
 import teamImg2 from '../images/about-img-3.jpg';
@@ -13,6 +13,19 @@ function CoreTeam() {
     { id: 5, name: "Mazen Ahmed", role: "VICE-PRESIDENT", major: "M.A", img: teamImg2 },
     { id: 6, name: "Godwill Attisso", role: "VICE-PRESIDENT", major: "G.A", img: teamImg1 },
   ];
+
+  useEffect(()=>{
+    const track = document.querySelector('.core-team__sliding-track');
+    if(track){
+      const trackItems = track.children; // Changed from items to trackItems
+      Array.from(trackItems).forEach(element => {
+        const clone = element.cloneNode(true);
+        track.appendChild(clone);
+      });
+  
+    }
+  },[]);
+
 
   return (
     <div className="core-team">


### PR DESCRIPTION
## `fix(about): resolve infinite scroll issue on About Page (#18)`

---

## Description (required)
<!-- Brief summary of the change. One or two lines. -->
This PR fixes the CSS infinite-scroll behaviour on the About Page so member cards loop/repeat smoothly. 
---

## What I changed
- Fixed CSS enabling infinite scroll for the About Page cards.
- Adjusted scroll window size for improved UX.
- Ensured cards loop/repeat correctly.

---

## How to test
1. Pull this branch.
2. Run the local site (e.g. `npm start` / `yarn start` / `pnpm dev`).
3. Navigate to About Page and verify infinite scroll loops and layout stability.

---

## Screenshots / 
<img width="1920" height="1080" alt="Screenshot (12)" src="https://github.com/user-attachments/assets/58c39479-1fbb-4bc8-8c43-05cfcb99201f" />


## Related Issue / Fixes
Fixes #18

---
